### PR TITLE
Update discord.py Version

### DIFF
--- a/liberty-core-docker/requirements.txt
+++ b/liberty-core-docker/requirements.txt
@@ -1,5 +1,5 @@
 discord.py==2.2.2
 pyyaml==5.3
 PyNaCl==1.4.0
-git+https://github.com/pytube/pytube.git@v10.5.1
+git+https://github.com/pytube/pytube.git@v12.1.3
 validators==0.18.2

--- a/liberty-core-docker/requirements.txt
+++ b/liberty-core-docker/requirements.txt
@@ -1,4 +1,4 @@
-discord.py==1.5.1
+discord.py==2.2.2
 pyyaml==5.3
 PyNaCl==1.4.0
 git+https://github.com/pytube/pytube.git@v10.5.1

--- a/liberty/bot.py
+++ b/liberty/bot.py
@@ -47,7 +47,7 @@ _COGS = define_cogs()
 async def on_ready():
     print(_COGS)
     for name, cog in _COGS.items():
-        bot.add_cog(cog[0](bot))
+        await bot.add_cog(cog[0](bot))
     print(f'Bot connected as {bot.user}')
     print(f'Bot is living in {bot.guilds}')
 
@@ -62,7 +62,7 @@ async def reload_cogs(context, cog=None):
         reload(sys.modules[_COGS[cog][1]])
         _COGS = define_cogs()
         if cog not in _DISABLED_COGS:
-            bot.add_cog(_COGS[cog][0](bot))
+            await bot.add_cog(_COGS[cog][0](bot))
             reloaded.append(cog.upper())
     else:
         # Reload all cogs
@@ -73,7 +73,7 @@ async def reload_cogs(context, cog=None):
         _COGS = define_cogs()
         for name, cog in _COGS.items():
             if name not in _DISABLED_COGS:
-                bot.add_cog(cog[0](bot))
+                await bot.add_cog(cog[0](bot))
                 reloaded.append(name.upper())
     await context.send(f'RELOAD OF {reloaded} SECURED. AMERICAN VICTORY IS ASSURED.')
 

--- a/liberty/bot.py
+++ b/liberty/bot.py
@@ -58,7 +58,7 @@ async def reload_cogs(context, cog=None):
     global _COGS
     if cog and cog in _COGS.keys():
         # Reload single cog
-        bot.remove_cog(cog)
+        await bot.remove_cog(cog)
         reload(sys.modules[_COGS[cog][1]])
         _COGS = define_cogs()
         if cog not in _DISABLED_COGS:
@@ -67,7 +67,7 @@ async def reload_cogs(context, cog=None):
     else:
         # Reload all cogs
         for name, cog in _COGS.items():
-            bot.remove_cog(name)
+            await bot.remove_cog(name)
             print(cog)
             reload(sys.modules[cog[1]])
         _COGS = define_cogs()


### PR DESCRIPTION
this is a simple yet important fix to kick the tires on a couple of packages and get audio stuff working again. First was the version bump of discord.py, which also required a very small refactor (They made the loading/unloading of cogs asynchronous so I added awaits there). This gave us back most of our bot functionality. 

I also bumped the version of pytube, which seems to have allowed us to download audio from youtube again.

testing: Ran the bot locally and was able to hear audio regexes, play local files, call text commands, play youtube audio, and enable/disable/reload cogs successfully