### PR TITLE
Audio improvements

### DIFF
--- a/liberty-core-docker/requirements.txt
+++ b/liberty-core-docker/requirements.txt
@@ -1,5 +1,6 @@
 discord.py==2.2.2
 pyyaml==5.3
 PyNaCl==1.4.0
-git+https://github.com/pytube/pytube.git@v12.1.3
+pytube==12.1.3
+yt-dlp==2023.3.4
 validators==0.18.2

--- a/liberty/commands/audio.py
+++ b/liberty/commands/audio.py
@@ -1,8 +1,10 @@
 import discord
 from discord.ext import commands
+import os
 
 from handlers.audio import AudioHandler
 from utils.general import StrUtils, EmbedUtils
+from utils.constants import _AUDIO_DIR
 
 # A file for defining audio commands
 class Audio(commands.Cog):
@@ -56,12 +58,40 @@ class Audio(commands.Cog):
         await audio_handler.kill_music()
 
 
-    @commands.command(name='list', help='Lists songs in the queue')
+    @commands.command(name='save', help='Saves the selected song to the assets directory')
+    async def save_song(self, context, name, queue_position=None):
+        audio_handler = self._audio_handlers[context.guild.id]
+        if queue_position:
+            try:
+                queue_position = int(queue_position)
+            except:
+                # Probably should do some error reporting here, but.....
+                return
+        await audio_handler.save_song(name, queue_position)
+
+
+    @commands.command(name='availablesongs', help='Lists the available songs in the audio assets directory')
+    async def available_songs(self, context):
+        # Somehow get list of files in the audio dir
+        files = os.listdir(_AUDIO_DIR)
+        # Create an empty embed
+        embeds = [EmbedUtils.get_list_embed_base(title='Liberty Prime Available Audio Files', description='This is a list of the semi-persistent songs saved in the Liberty Prime audio directory')]
+        for file in files:
+            if len(embeds[-1].fields) >= 25:
+                embeds.append(EmbedUtils.get_list_embed_continuation(len(embeds), title='Liberty Prime Available Audio Files'))
+            EmbedUtils.add_available_song_field(embeds[-1], file)
+        if not embeds[0].fields:
+            EmbedUtils.add_empty_list_field(embeds[-1])
+        for embed in embeds:
+            await context.send(embed=embed)
+
+
+    @commands.command(name='playlist', help='Lists songs in the queue')
     async def list_queue(self, context):
         # TODO add more info per song including deepfried/regular, length, thumbnail
         audio_handler = self._audio_handlers[context.guild.id]
         # Create an empty embed
-        embeds = [EmbedUtils.get_list_embed_base()]
+        embeds = [EmbedUtils.get_list_embed_base(title='Liberty Prime Audio Queue', description='These are all of the songs waiting to be played by Liberty Prime')]
         # Add Now Playing Song
         if audio_handler.playing:
             EmbedUtils.add_now_playing_field(embeds[-1], audio_handler.playing)
@@ -69,7 +99,7 @@ class Audio(commands.Cog):
         q = audio_handler.get_queue()
         for song in q._queue:
             if len(embeds[-1].fields) >= 25:
-                embeds.append(EmbedUtils.get_list_embed_continuation(len(embeds)))
+                embeds.append(EmbedUtils.get_list_embed_continuation(len(embeds), title='Liberty Prime Audio Queue'))
             EmbedUtils.add_queued_song_field(embeds[-1], song)
         if not embeds[0].fields:
             EmbedUtils.add_empty_list_field(embeds[-1])

--- a/liberty/handlers/audio.py
+++ b/liberty/handlers/audio.py
@@ -1,5 +1,6 @@
 import discord
 import asyncio
+import shutil
 from pathlib import Path
 
 from utils.downloader import PytubeDownloader, YouTubeVideo
@@ -39,6 +40,21 @@ class AudioHandler:
     async def download_and_add_song(self, url, channel_id=None, manipulation=None, added_by=None):
         video = PytubeDownloader.download(url)
         return await self.add_song(video.path, channel_id, manipulation, video.title, source='Downloaded Youtube Audio', added_by=added_by)
+
+
+    async def save_song(self, name, queue_position=None):
+        if not self.playing:
+            print('Cannot save song if nothing is playing')
+            return False
+        # If no queue position is given, use currently playing song
+        song = self.playing
+        if queue_position is not None:
+            # I think it's slightly illegal to access the queue object this way
+            song = self.queue._queue[queue_position]
+        old_path = song.path
+        new_path = _AUDIO_DIR + name
+        shutil.copyfile(old_path, new_path)
+        return True
 
 
     async def add_song(self, song, channel_id=None, manipulation=None, name=None, source='Local Song', added_by=None):

--- a/liberty/utils/downloader.py
+++ b/liberty/utils/downloader.py
@@ -1,4 +1,6 @@
 from pytube import YouTube
+from yt_dlp import YoutubeDL
+import json
 
 from utils.constants import _TMP_DIR
 from utils.general import FSUtils, StrUtils
@@ -17,14 +19,35 @@ class PytubeDownloader():
         if not url:
             print("Must Provide URL")
             return None
-        yt = YouTube(url)
-        if not video:
-            streams = yt.streams.filter(only_audio=True)
-        else:
-            streams = yt.streams.filter(progressive=True)
-        # Could filter here to get preferred resolution/file type
-        # For more specificity on video/audio would have to move inside the 'if'
-        ys = streams.first()
-        path = ys.download(output_path=_TMP_DIR, filename=StrUtils.generateFilename('youtube'))
-        return YouTubeVideo(yt.title, path, yt.length, video)
+        # Try to download with pytube, if that fails use yt-dlp
+        # TODO: Abstract this into two separate downloader classes and somehow choose between the two (or try them all)
+        try:
+            yt = YouTube(url)
+            if not video:
+                streams = yt.streams.filter(only_audio=True)
+            else:
+                streams = yt.streams.filter(progressive=True)
+            # Could filter here to get preferred resolution/file type
+            # For more specificity on video/audio would have to move inside the 'if'
+            ys = streams.first()
+            title = yt.title
+            path = ys.download(output_path=_TMP_DIR, filename=StrUtils.generateFilename('youtube'))
+            length = yt.length
+        except:
+            ydl_opts = {
+                'format': 'm4a/bestaudio/best',
+                # ℹ️ See help(yt_dlp.postprocessor) for a list of available Postprocessors and their arguments
+                'postprocessors': [{  # Extract audio using ffmpeg
+                    'key': 'FFmpegExtractAudio',
+                    'preferredcodec': 'm4a',
+                }],
+                'outtmpl': {'default': _TMP_DIR + '%(id)s.%(ext)s'}
+            }
+            with YoutubeDL(ydl_opts) as ydl:
+                info = ydl.sanitize_info(ydl.extract_info(url, download=True))
+                title = info.get('title')
+                path = _TMP_DIR + info.get('id') + '.' + info.get('ext')
+                length = info.get('duration')
+            pass
+        return YouTubeVideo(title, path, length, video)
 

--- a/liberty/utils/downloader.py
+++ b/liberty/utils/downloader.py
@@ -34,9 +34,9 @@ class PytubeDownloader():
             path = ys.download(output_path=_TMP_DIR, filename=StrUtils.generateFilename('youtube'))
             length = yt.length
         except:
+            # TODO: Fix known issue where the tmpfile output is not a unique filename, so adding the same video to the queue multiple times causes it to get deleted too early
             ydl_opts = {
                 'format': 'm4a/bestaudio/best',
-                # ℹ️ See help(yt_dlp.postprocessor) for a list of available Postprocessors and their arguments
                 'postprocessors': [{  # Extract audio using ffmpeg
                     'key': 'FFmpegExtractAudio',
                     'preferredcodec': 'm4a',

--- a/liberty/utils/general.py
+++ b/liberty/utils/general.py
@@ -29,12 +29,12 @@ class StrUtils():
 
 class EmbedUtils():
     @staticmethod
-    def get_list_embed_base():
-        return discord.Embed(title='Liberty Prime Audio Queue', url='https://patriots.win/', color=0x500000, description='These are all of the songs waiting to be played by Liberty Prime')
+    def get_list_embed_base(title, description):
+        return discord.Embed(title=title, url='https://patriots.win/', color=0x500000, description=description)
 
 
     @staticmethod
-    def get_list_embed_continuation(pagenum):
+    def get_list_embed_continuation(pagenum, title, description=None):
         if pagenum%3 == 0:
             # Red (Aggie Maroon, Gig 'em!)
             color = 0x500000
@@ -44,7 +44,7 @@ class EmbedUtils():
         else:
             # Blue
             color = 0x0000ff
-        return discord.Embed(title='Liberty Prime Audio Queue Page ' + str(pagenum+1), url='https://patriots.win/', color=color)
+        return discord.Embed(title=title + ' Page ' + str(pagenum+1), url='https://patriots.win/', color=color, description=description)
 
 
     @staticmethod
@@ -60,3 +60,8 @@ class EmbedUtils():
     @staticmethod
     def add_queued_song_field(embed, song):
         embed.add_field(name=song.name, value=song.source + ' Added By: ' + song.added_by.display_name, inline=False)
+
+
+    @staticmethod
+    def add_available_song_field(embed, filename):
+        embed.add_field(name=filename, value='')


### PR DESCRIPTION
This accomplishes two main things:
One is a braindead implementation of a second youtube downloader. Improvements to come here, but currently if it fails to download with pytube, it'll try again with the new downloader. I mostly needed this because pytube was completely broken today.

The main goal of this change was to add the functionality of saving downloaded songs to the audio asset directory to be replayed without re-downloading. This has been a fan-favorite terminus feature so I'm getting a start on implementing it here. I would say it's almost fully-functional, but hopefully improvements and refactors are coming soon.