### PR TITLE
Audio Stream Merge feature

### DIFF
--- a/liberty-core-docker/requirements.txt
+++ b/liberty-core-docker/requirements.txt
@@ -1,5 +1,6 @@
 boto3==1.28.40
 discord.py==2.2.2
+ffmpeg-python==0.2.0
 pyyaml==5.3
 PyNaCl==1.4.0
 pytube==15.0.0

--- a/liberty/commands/audio.py
+++ b/liberty/commands/audio.py
@@ -49,6 +49,29 @@ class Audio(commands.Cog):
             await context.send('This audio file could not be played')
 
 
+    @commands.command(name='merge', help='Merges multiple audio sources and plays the result')
+    async def play_song(self, context, *args):
+        sources = []
+        length = None
+        channel_id = None
+        try:
+            for arg in args:
+                if arg.startswith('length'):
+                    length = float(arg.split('=')[1])
+                elif arg.startswith('channel_id'):
+                    channel_id = arg.split('=')[1]
+                else:
+                    sources.append(arg)
+        except:
+            await context.send('Failed to parse arguments, do better next time')
+            return
+        audio_handler = self._audio_handlers[context.guild.id]
+        added_by=context.author
+        res = await audio_handler.merge_and_add_song(sources, length, channel_id, added_by=added_by)
+        if not res:
+            await context.send('This audio file could not be played')
+
+
     @commands.command(name='next', help='Plays the next song in the queue')
     async def play_next(self, context):
         audio_handler = self._audio_handlers[context.guild.id]

--- a/liberty/utils/general.py
+++ b/liberty/utils/general.py
@@ -2,10 +2,24 @@ import discord
 from pathlib import Path
 import validators
 import datetime
+import os
+import shutil
+from contextlib import contextmanager
 
 from utils.constants import _TMP_DIR
 
 class FSUtils():
+    @staticmethod
+    @contextmanager
+    def temp_directory():
+        dirname = _TMP_DIR + StrUtils.generateFilename() + '/'
+        try:
+            os.mkdir(dirname)
+            yield dirname
+        finally:
+            shutil.rmtree(dirname)
+
+
     @staticmethod
     def isTmpDir(path):
         # Return true if this file is anywhere in the tmp dir


### PR DESCRIPTION
This implements the feature of being able to pass in multiple audio streams (currently pre-downloaded files or youtube URLs) and have ffmpeg merge them into one audio stream playing concurrently, and then play that audio stream the same as any other song.

testing:
I ran the new command a few times with various inputs, including specifying the two extraneous parameters, and saw that it worked.